### PR TITLE
 [fix] over scrolling on iOS

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -329,13 +329,20 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       return;
     }
     const frame = this._getFrameMetricsApprox(index);
-    const offset =
+    const maxScroll =
+      this._scrollMetrics.contentLength - this._scrollMetrics.visibleLength;
+    let offset =
       Math.max(
         0,
         frame.offset -
           (viewPosition || 0) *
             (this._scrollMetrics.visibleLength - frame.length),
       ) - (viewOffset || 0);
+
+    /* Fix for overscrolling */
+    if (offset > maxScroll) {
+      offset = maxScroll;
+    }
     /* $FlowFixMe(>=0.53.0 site=react_native_fb,react_native_oss) This comment
      * suppresses an error when upgrading Flow's support for React. To see the
      * error delete this comment and run Flow. */


### PR DESCRIPTION
修复这个问题 https://github.com/facebook/react-native/pull/23181

 下面的 cpojer 提出 `overScrollMode="never"` 在 iOS 上这个字段是无效的，也不知道为啥就直接关了。。

等后面升级到 0.59 了还有这个问题再去开 issue